### PR TITLE
Limit snapshot pruning to the current host

### DIFF
--- a/config.ps1
+++ b/config.ps1
@@ -14,7 +14,7 @@ $AdditionalBackupParameters = @("--exclude-if-present", ".nobackup")
 
 # maintenance configuration
 $SnapshotMaintenanceEnabled = $true
-$SnapshotRetentionPolicy = @("--group-by", "host,tags", "--keep-daily", "30", "--keep-weekly", "52", "--keep-monthly", "24", "--keep-yearly", "10")
+$SnapshotRetentionPolicy = @("--host", $env:COMPUTERNAME, "--group-by", "tags", "--keep-daily", "30", "--keep-weekly", "52", "--keep-monthly", "24", "--keep-yearly", "10")
 $SnapshotPrunePolicy = @("--max-unused", "1%")
 $SnapshotMaintenanceInterval = 7
 $SnapshotMaintenanceDays = 30


### PR DESCRIPTION
Address #70 by only pruning snapshots from the current host by default when performing maintenance.  This avoids inadvertently pruning snapshots from other hosts when that might not be desired.